### PR TITLE
UART mode improvements

### DIFF
--- a/Adafruit_Soundboard.cpp
+++ b/Adafruit_Soundboard.cpp
@@ -90,7 +90,7 @@ boolean Adafruit_Soundboard::reset(void) {
 
 
 // Query the board for the # of files and names/sizes
-uint8_t Adafruit_Soundboard::listFiles(fileListHandler handler) {
+uint8_t Adafruit_Soundboard::listFiles(FileInfo* infoArr, int nInfoArr, fileListHandler handler) {
   uint32_t filesize;
 
   while (stream->available())
@@ -99,6 +99,7 @@ uint8_t Adafruit_Soundboard::listFiles(fileListHandler handler) {
   stream->println('L'); // 'L' for 'l'ist
 
   uint8_t nFiles = 0;
+  FileInfo info;
   
   while (stream->readBytesUntil('\n', line_buffer, LINE_BUFFER_SIZE)) {
     const char* filename = line_buffer;
@@ -114,7 +115,15 @@ uint8_t Adafruit_Soundboard::listFiles(fileListHandler handler) {
        size *= 10;
        size += c - '0';
     }
-    handler(nFiles, filename, size);
+
+    memcpy(info.filename, line_buffer, 12);
+    info.size = size;
+
+    if (infoArr && nFiles < nInfoArr)
+      infoArr[nFiles] = info;
+    if (handler)
+      handler(nFiles, info);
+
     nFiles++;
   }
   return nFiles;

--- a/Adafruit_Soundboard.h
+++ b/Adafruit_Soundboard.h
@@ -24,7 +24,13 @@
 
 #include "Arduino.h"
 
-typedef void (*fileListHandler)(uint8_t id, const char* fileName, uint32_t fileSize);
+struct FileInfo
+{
+  char      filename[12];
+  uint32_t  size;
+};
+
+typedef void (*fileListHandler)(uint8_t id, const FileInfo& fileInfo);
 
 class Adafruit_Soundboard : public Print {
  public:
@@ -33,7 +39,17 @@ class Adafruit_Soundboard : public Print {
   boolean reset(void);
 
   int     readLine(void);
-  uint8_t listFiles(fileListHandler handler);
+  /**
+   *  Gets a list of files. You may pass in:
+   *  - a pointer to an array of FileInfo structures, and the size
+   *    (nInfoArr) of that array. listFiles() will fill in the 
+   *    filenames and size of the files.
+   * - a callback function to be called for each file in the list.
+   * 
+   * You may pass in either, both, or neither. The number of files
+   * is returned.
+   */
+  uint8_t listFiles(FileInfo* infoArr, int nInfoArr, fileListHandler handler);
 
   uint8_t volUp(void);
   uint8_t volDown(void);

--- a/Adafruit_Soundboard.h
+++ b/Adafruit_Soundboard.h
@@ -24,27 +24,23 @@
 
 #include "Arduino.h"
 
-#define LINE_BUFFER_SIZE  80
-#define MAXFILES 25
+typedef void (*fileListHandler)(uint8_t id, const char* fileName, uint32_t fileSize);
 
 class Adafruit_Soundboard : public Print {
  public:
-  Adafruit_Soundboard(Stream *s, Stream *d, int8_t r);
+  Adafruit_Soundboard(Stream *stream, Stream *debug, int8_t r);
 
   boolean reset(void);
 
   int     readLine(void);
-  uint8_t listFiles(void);
-
-  char *fileName(uint8_t n);
-  uint32_t fileSize(uint8_t n);
-
+  uint8_t listFiles(fileListHandler handler);
 
   uint8_t volUp(void);
   uint8_t volDown(void);
+  uint8_t setVol(uint8_t vol);
 
   boolean playTrack(uint8_t n);
-  boolean playTrack(char *name);
+  boolean playTrack(const char *name);
   boolean pause(void);
   boolean unpause(void);
   boolean stop(void);
@@ -53,18 +49,14 @@ class Adafruit_Soundboard : public Print {
   boolean trackSize(uint32_t *current, uint32_t *total);
 
  private:
+  enum { LINE_BUFFER_SIZE = 80 };
+
   Stream   *stream;     // -> sound board, e.g. SoftwareSerial or Serial1
   Stream    *debug;      // -> host, e.g. Serial
   
   int8_t reset_pin;
   char line_buffer[LINE_BUFFER_SIZE];
   boolean writing;
-
-  // File name & size caching
-  uint8_t files;
-  char filenames[MAXFILES][12];
-  uint32_t filesizes[MAXFILES];
-
 
   virtual size_t write(uint8_t); // Because Print subclass
 };

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -45,8 +45,14 @@ void setup() {
     while (1);
   }
   Serial.println("SFX board found");
+  sfx.setVol(180);
 }
 
+void fileListItem(uint8_t id, const char* fileName, uint32_t fileSize){
+  Serial.print(id); 
+  Serial.print("\tname: "); Serial.print(fileName);
+  Serial.print("\tsize: "); Serial.println(fileSize);
+}
 
 void loop() {
   flushInput();
@@ -55,6 +61,7 @@ void loop() {
   Serial.println(F("[r] - reset"));
   Serial.println(F("[+] - Vol +"));
   Serial.println(F("[-] - Vol -"));
+  Serial.println(F("[V] - set volume (0-204)"));
   Serial.println(F("[L] - List files"));
   Serial.println(F("[P] - play by file name"));
   Serial.println(F("[#] - play by file number"));
@@ -78,18 +85,11 @@ void loop() {
     }
     
     case 'L': {
-      uint8_t files = sfx.listFiles();
-    
       Serial.println("File Listing");
       Serial.println("========================");
-      Serial.println();
-      Serial.print("Found "); Serial.print(files); Serial.println(" Files");
-      for (uint8_t f=0; f<files; f++) {
-        Serial.print(f); 
-        Serial.print("\tname: "); Serial.print(sfx.fileName(f));
-        Serial.print("\tsize: "); Serial.println(sfx.fileSize(f));
-      }
-      Serial.println("========================");
+      uint8_t nFiles = sfx.listFiles(fileListItem);
+      Serial.print("Found "); Serial.print(nFiles); Serial.println(" Files");
+      Serial.println("========================");  
       break; 
     }
     
@@ -138,6 +138,14 @@ void loop() {
       }
       break;
    }
+
+   case 'V': {
+      Serial.println("Vol...");
+      uint8_t v = readnumber();
+      Serial.print("Volume: "); 
+      Serial.println(v);
+      break;
+    }
    
    case '=': {
       Serial.println("Pausing...");

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -23,14 +23,18 @@
 // You can also monitor the ACT pin for when audio is playing!
 
 // we'll be using software serial
-SoftwareSerial ss = SoftwareSerial(SFX_TX, SFX_RX);
+SoftwareSerial ss(SFX_TX, SFX_RX);
 
 // pass the software serial to Adafruit_soundboard, the second
 // argument is the debug port (not used really) and the third 
 // arg is the reset pin
-Adafruit_Soundboard sfx = Adafruit_Soundboard(&ss, NULL, SFX_RST);
+Adafruit_Soundboard sfx(&ss, NULL, SFX_RST);
+
 // can also try hardware serial with
-// Adafruit_Soundboard sfx = Adafruit_Soundboard(&Serial1, NULL, SFX_RST);
+// Adafruit_Soundboard sfx(&Serial1, NULL, SFX_RST);
+
+static const int MAX_FILES = 25;
+FileInfo fileInfo[MAX_FILES];
 
 void setup() {
   Serial.begin(115200);
@@ -48,10 +52,10 @@ void setup() {
   sfx.setVol(180);
 }
 
-void fileListItem(uint8_t id, const char* fileName, uint32_t fileSize){
+void fileListItem(uint8_t id, const FileInfo& info){
   Serial.print(id); 
-  Serial.print("\tname: "); Serial.print(fileName);
-  Serial.print("\tsize: "); Serial.println(fileSize);
+  Serial.print("\tname: "); Serial.print(info.filename);
+  Serial.print("\tsize: "); Serial.println(info.size);
 }
 
 void loop() {
@@ -87,7 +91,19 @@ void loop() {
     case 'L': {
       Serial.println("File Listing");
       Serial.println("========================");
-      uint8_t nFiles = sfx.listFiles(fileListItem);
+
+      // 2 ways to do the same thing.
+#if 0
+      int nFiles = sfx.listFiles(fileInfo, MAX_FILES, 0);
+      for(int i = 0; i < nFiles; i++) {
+        Serial.print(i); 
+        Serial.print("\tname: "); Serial.print(fileInfo[i].filename);
+        Serial.print("\tsize: "); Serial.println(fileInfo[i].size);
+      }
+#else
+      int nFiles = sfx.listFiles(0, 0, fileListItem);
+#endif
+      
       Serial.print("Found "); Serial.print(nFiles); Serial.println(" Files");
       Serial.println("========================");  
       break; 
@@ -142,6 +158,7 @@ void loop() {
    case 'V': {
       Serial.println("Vol...");
       uint8_t v = readnumber();
+      sfx.setVol(v);
       Serial.print("Volume: "); 
       Serial.println(v);
       break;


### PR DESCRIPTION
I love the AudioFX UART mode, and the help code is great to work through the details of the serial transmission. I did try to clean up a few issues:
- The file name/size cache is a significant amount of memory, and limits the class to working with 25 files. Both issues are addressed with a callback.
- Setting volume to a particular value is now supported. (Extra helpful in setup() if you are possibly overdriving your speaker.)
- Minor C++ cleanups.
