### PR TITLE
Use Adafruit_Soundboard print functionality

### DIFF
--- a/Adafruit_Soundboard.h
+++ b/Adafruit_Soundboard.h
@@ -1,4 +1,4 @@
-/*************************************************** 
+/***************************************************
   This is a library for the Adafruit Sound Boards in UART mode
 
   ----> http://www.adafruit.com/products/2342
@@ -55,7 +55,7 @@ class Adafruit_Soundboard : public Print {
  private:
   Stream   *stream;     // -> sound board, e.g. SoftwareSerial or Serial1
   Stream    *debug;      // -> host, e.g. Serial
-  
+
   int8_t reset_pin;
   char line_buffer[LINE_BUFFER_SIZE];
   boolean writing;
@@ -67,5 +67,6 @@ class Adafruit_Soundboard : public Print {
 
 
   virtual size_t write(uint8_t); // Because Print subclass
+  virtual size_t write(const uint8_t *buffer, size_t size);
 };
 #endif

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -1,4 +1,4 @@
-/* 
+/*
   Menu driven control of a sound board over UART.
   Commands for playing by # or by name (full 11-char name)
   Hard reset and List files (when not playing audio)
@@ -26,7 +26,7 @@
 SoftwareSerial ss = SoftwareSerial(SFX_TX, SFX_RX);
 
 // pass the software serial to Adafruit_soundboard, the second
-// argument is the debug port (not used really) and the third 
+// argument is the debug port (not used really) and the third
 // arg is the reset pin
 Adafruit_Soundboard sfx = Adafruit_Soundboard(&ss, NULL, SFX_RST);
 // can also try hardware serial with
@@ -35,7 +35,7 @@ Adafruit_Soundboard sfx = Adafruit_Soundboard(&ss, NULL, SFX_RST);
 void setup() {
   Serial.begin(115200);
   Serial.println("Adafruit Sound Board!");
-  
+
   // softwareserial at 9600 baud
   ss.begin(9600);
   // can also do Serial1.begin(9600)
@@ -50,7 +50,7 @@ void setup() {
 
 void loop() {
   flushInput();
-  
+
   Serial.println(F("What would you like to do?"));
   Serial.println(F("[r] - reset"));
   Serial.println(F("[+] - Vol +"));
@@ -62,37 +62,38 @@ void loop() {
   Serial.println(F("[>] - unpause playing"));
   Serial.println(F("[q] - stop playing"));
   Serial.println(F("[t] - playtime status"));
+  Serial.println(F("[s] - track size"));
   Serial.println(F("> "));
-  
+
   while (!Serial.available());
   char cmd = Serial.read();
-  
+
   flushInput();
-  
+
   switch (cmd) {
     case 'r': {
       if (!sfx.reset()) {
         Serial.println("Reset failed");
       }
-      break; 
+      break;
     }
-    
+
     case 'L': {
       uint8_t files = sfx.listFiles();
-    
+
       Serial.println("File Listing");
       Serial.println("========================");
       Serial.println();
       Serial.print("Found "); Serial.print(files); Serial.println(" Files");
       for (uint8_t f=0; f<files; f++) {
-        Serial.print(f); 
+        Serial.print(f);
         Serial.print("\tname: "); Serial.print(sfx.fileName(f));
         Serial.print("\tsize: "); Serial.println(sfx.fileSize(f));
       }
       Serial.println("========================");
-      break; 
+      break;
     }
-    
+
     case '#': {
       Serial.print("Enter track #");
       uint8_t n = readnumber();
@@ -103,13 +104,13 @@ void loop() {
       }
       break;
     }
-    
+
     case 'P': {
       Serial.print("Enter track name (full 12 character name!) >");
       char name[20];
       readline(name, 20);
 
-      Serial.print("\nPlaying track \""); Serial.print(name); Serial.print("\"");
+      Serial.print("\nPlaying track \""); Serial.print(name); Serial.println("\"");
       if (! sfx.playTrack(name) ) {
         Serial.println("Failed to play track?");
       }
@@ -132,30 +133,30 @@ void loop() {
       uint16_t v;
       if (! (v=sfx.volDown()) ) {
         Serial.println("Failed to adjust");
-      } else { 
-        Serial.print("Volume: "); 
+      } else {
+        Serial.print("Volume: ");
         Serial.println(v);
       }
       break;
    }
-   
+
    case '=': {
       Serial.println("Pausing...");
       if (! sfx.pause() ) Serial.println("Failed to pause");
       break;
    }
-   
+
    case '>': {
       Serial.println("Unpausing...");
       if (! sfx.unpause() ) Serial.println("Failed to unpause");
       break;
    }
-   
+
    case 'q': {
       Serial.println("Stopping...");
       if (! sfx.stop() ) Serial.println("Failed to stop");
       break;
-   }  
+   }
 
    case 't': {
       Serial.print("Track time: ");
@@ -163,16 +164,16 @@ void loop() {
       if (! sfx.trackTime(&current, &total) ) Serial.println("Failed to query");
       Serial.print(current); Serial.println(" seconds");
       break;
-   }  
+   }
 
    case 's': {
       Serial.print("Track size (bytes remaining/total): ");
       uint32_t remain, total;
-      if (! sfx.trackSize(&remain, &total) ) 
+      if (! sfx.trackSize(&remain, &total) )
         Serial.println("Failed to query");
-      Serial.print(remain); Serial.print("/"); Serial.println(total); 
+      Serial.print(remain); Serial.print("/"); Serial.println(total);
       break;
-   }  
+   }
 
   }
 }
@@ -219,7 +220,7 @@ uint16_t readnumber() {
 
 uint8_t readline(char *buff, uint8_t maxbuff) {
   uint16_t buffidx = 0;
-  
+
   while (true) {
     if (buffidx > maxbuff) {
       break;


### PR DESCRIPTION
As I mentioned in Issue #6, I just made changes wherever `stream->print` or `stream->println` was used and changed it to `print` or `println`. I also subclassed the other write method `size_t write(const uint8_t *buffer, size_t size)`. Doing this allows the detection of when a command is finished `writing`. This then allows for that variable to be set back to `false`. There were also some places in the code that wasn't using the `readline` method for reading data and were instead just reusing the code that is used in the `readline` method unnecessarily. I fixed those and they are now also using `readline`.

The second commit just fixes the sample project to show the '[s] - track size' option in the menu that gets printed for the user.

I've tested all of these on my Soundboard and they work!

Let me know if there is anything else you need me to do!