### PR TITLE
Fixes to menucommands.ino.

### DIFF
--- a/Adafruit_Soundboard.cpp
+++ b/Adafruit_Soundboard.cpp
@@ -109,8 +109,7 @@ boolean Adafruit_Soundboard::reset(void) {
  * @return Returns the information about the files
  */
 uint8_t Adafruit_Soundboard::listFiles(void) {
-  uint32_t filesize;
-
+  
   while (stream->available())
     stream->read();
 

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -71,7 +71,7 @@ void loop() {
   switch (lineBuffer[0]) {
     case 'r': {
       if (!sfx.reset()) {
-        Serial.println("Reset failed");
+        Serial.println(F("Reset failed"));
       }
       break; 
     }
@@ -79,97 +79,97 @@ void loop() {
     case 'L': {
       uint8_t files = sfx.listFiles();
     
-      Serial.println("File Listing");
-      Serial.println("========================");
+      Serial.println(F("File Listing"));
+      Serial.println(F("========================"));
       Serial.println();
-      Serial.print("Found "); Serial.print(files); Serial.println(" Files");
+      Serial.print(F("Found ")); Serial.print(files); Serial.println(F(" Files"));
       for (uint8_t f=0; f<files; f++) {
         Serial.print(f); 
-        Serial.print("\tname: "); Serial.print(sfx.fileName(f));
-        Serial.print("\tsize: "); Serial.println(sfx.fileSize(f));
+        Serial.print(F("\tname: ")); Serial.print(sfx.fileName(f));
+        Serial.print(F("\tsize: ")); Serial.println(sfx.fileSize(f));
       }
-      Serial.println("========================");
+      Serial.println(F("========================"));
       break; 
     }
     
     case '#': {
-      Serial.print("Enter track #");
+      Serial.print(F("Enter track #"));
       uint8_t n = readnumber();
 
-      Serial.print("\nPlaying track #"); Serial.println(n);
+      Serial.print(F("\nPlaying track #")); Serial.println(n);
       if (! sfx.playTrack((uint8_t)n) ) {
-        Serial.println("Failed to play track?");
+        Serial.println(F("Failed to play track?"));
       }
       break;
     }
     
     case 'P': {
-      Serial.print("Enter track name (full 12 character name!) >");
+      Serial.print(F("Enter track name (full 12 character name!) >"));
       readline(lineBuffer, bufferSize);
 
-      Serial.print("\nPlaying track \""); Serial.print(lineBuffer); Serial.print("\"");
+      Serial.print(F("\nPlaying track \"")); Serial.print(lineBuffer); Serial.print(F("\""));
       if (! sfx.playTrack(lineBuffer) ) {
-        Serial.println("Failed to play track?");
+        Serial.println(F("Failed to play track?"));
       }
       break;
    }
 
    case '+': {
-      Serial.println("Vol up...");
+      Serial.println(F("Vol up..."));
       uint16_t v;
       if (! (v = sfx.volUp()) ) {
-        Serial.println("Failed to adjust");
+        Serial.println(F("Failed to adjust"));
       } else {
-        Serial.print("Volume: "); Serial.println(v);
+        Serial.print(F("Volume: ")); Serial.println(v);
       }
       break;
    }
 
    case '-': {
-      Serial.println("Vol down...");
+      Serial.println(F("Vol down..."));
       uint16_t v;
       if (! (v=sfx.volDown()) ) {
-        Serial.println("Failed to adjust");
+        Serial.println(F("Failed to adjust"));
       } else { 
-        Serial.print("Volume: "); 
+        Serial.print(F("Volume: "));
         Serial.println(v);
       }
       break;
    }
    
    case '=': {
-      Serial.println("Pausing...");
-      if (! sfx.pause() ) Serial.println("Failed to pause");
+      Serial.println(F("Pausing..."));
+      if (! sfx.pause() ) Serial.println(F("Failed to pause"));
       break;
    }
    
    case '>': {
-      Serial.println("Unpausing...");
-      if (! sfx.unpause() ) Serial.println("Failed to unpause");
+      Serial.println(F("Unpausing..."));
+      if (! sfx.unpause() ) Serial.println(F("Failed to unpause"));
       break;
    }
    
    case 'q': {
-      Serial.println("Stopping...");
-      if (! sfx.stop() ) Serial.println("Failed to stop");
+      Serial.println(F("Stopping..."));
+      if (! sfx.stop() ) Serial.println(F("Failed to stop"));
       break;
    }  
 
    case 't': {
-      Serial.print("Track time: ");
+      Serial.print(F("Track time: "));
       uint32_t current = 0;
 	  uint32_t total = 0;
-      if (! sfx.trackTime(&current, &total) ) Serial.println("Failed to query");
-      Serial.print(current); Serial.println(" seconds");
+      if (! sfx.trackTime(&current, &total) ) Serial.println(F("Failed to query"));
+      Serial.print(current); Serial.println(F(" seconds"));
       break;
    }  
 
    case 's': {
-      Serial.print("Track size (bytes remaining/total): ");
+      Serial.print(F("Track size (bytes remaining/total): "));
       uint32_t remain = 0;
 	  uint32_t total = 0;
       if (! sfx.trackSize(&remain, &total) ) 
-        Serial.println("Failed to query");
+        Serial.println(F("Failed to query"));
       Serial.print(remain); Serial.print("/"); Serial.println(total); 
       break;
    }  

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -49,7 +49,7 @@ void setup() {
 
 
 void loop() {
-
+  Serial.println();
   Serial.println(F("What would you like to do?"));
   Serial.println(F("[r] - reset"));
   Serial.println(F("[+] - Vol +"));
@@ -72,17 +72,19 @@ void loop() {
     case 'r': {
       if (!sfx.reset()) {
         Serial.println(F("Reset failed"));
-      }
+      } else {
+        Serial.println(F("Reset succeeded"));
+	  }
+	  
       break; 
     }
     
     case 'L': {
       uint8_t files = sfx.listFiles();
-    
+      
       Serial.println(F("File Listing"));
       Serial.println(F("========================"));
-      Serial.println();
-      Serial.print(F("Found ")); Serial.print(files); Serial.println(F(" Files"));
+      Serial.print(F("Found ")); Serial.print(files); Serial.println(F(" files"));
       for (uint8_t f=0; f<files; f++) {
         Serial.print(f); 
         Serial.print(F("\tname: ")); Serial.print(sfx.fileName(f));
@@ -93,10 +95,11 @@ void loop() {
     }
     
     case '#': {
-      Serial.print(F("Enter track #"));
+      Serial.println(F("Enter track #"));
+	  Serial.println(F("> "));
       uint8_t n = readnumber();
 
-      Serial.print(F("\nPlaying track #")); Serial.println(n);
+      Serial.print(F("Playing track #")); Serial.println(n);
       if (! sfx.playTrack((uint8_t)n) ) {
         Serial.println(F("Failed to play track?"));
       }
@@ -104,17 +107,18 @@ void loop() {
     }
     
     case 'P': {
-      Serial.print(F("Enter track name (full 12 character name!) >"));
+      Serial.println(F("Enter track name (full 12 character name!)"));
+	  Serial.println(F("> "));
       readline(lineBuffer, bufferSize);
 
-      Serial.print(F("\nPlaying track \"")); Serial.print(lineBuffer); Serial.print(F("\""));
+      Serial.print(F("Playing track \"")); Serial.print(lineBuffer); Serial.println(F("\""));
       if (! sfx.playTrack(lineBuffer) ) {
         Serial.println(F("Failed to play track?"));
       }
       break;
    }
 
-   case '+': {
+    case '+': {
       Serial.println(F("Vol up..."));
       uint16_t v;
       if (! (v = sfx.volUp()) ) {
@@ -123,9 +127,9 @@ void loop() {
         Serial.print(F("Volume: ")); Serial.println(v);
       }
       break;
-   }
+    }
 
-   case '-': {
+    case '-': {
       Serial.println(F("Vol down..."));
       uint16_t v;
       if (! (v=sfx.volDown()) ) {
@@ -135,36 +139,36 @@ void loop() {
         Serial.println(v);
       }
       break;
-   }
+    }
    
-   case '=': {
+    case '=': {
       Serial.println(F("Pausing..."));
       if (! sfx.pause() ) Serial.println(F("Failed to pause"));
       break;
-   }
+    }
    
-   case '>': {
+    case '>': {
       Serial.println(F("Unpausing..."));
       if (! sfx.unpause() ) Serial.println(F("Failed to unpause"));
       break;
-   }
+    }
    
-   case 'q': {
+    case 'q': {
       Serial.println(F("Stopping..."));
       if (! sfx.stop() ) Serial.println(F("Failed to stop"));
       break;
-   }  
+    }  
 
-   case 't': {
+    case 't': {
       Serial.print(F("Track time: "));
       uint32_t current = 0;
 	  uint32_t total = 0;
       if (! sfx.trackTime(&current, &total) ) Serial.println(F("Failed to query"));
       Serial.print(current); Serial.println(F(" seconds"));
       break;
-   }  
+    }  
 
-   case 's': {
+    case 's': {
       Serial.print(F("Track size (bytes remaining/total): "));
       uint32_t remain = 0;
 	  uint32_t total = 0;
@@ -172,8 +176,12 @@ void loop() {
         Serial.println(F("Failed to query"));
       Serial.print(remain); Serial.print("/"); Serial.println(total); 
       break;
-   }  
+    }  
 
+    default: {
+      Serial.println(F("Invalid entry, try again"));
+      break;
+    }
   }
 }
 
@@ -195,10 +203,10 @@ uint16_t readnumber() {
   while (! isdigit(c = readBlocking())) {
     //Serial.print(c);
   }
-  Serial.print(c);
+  //Serial.print(c);
   x = c - '0';
   while (isdigit(c = readBlocking())) {
-    Serial.print(c);
+    //Serial.print(c);
     x *= 10;
     x += c - '0';
   }

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -159,7 +159,8 @@ void loop() {
 
    case 't': {
       Serial.print("Track time: ");
-      uint32_t current, total;
+      uint32_t current = 0;
+	  uint32_t total = 0;
       if (! sfx.trackTime(&current, &total) ) Serial.println("Failed to query");
       Serial.print(current); Serial.println(" seconds");
       break;
@@ -167,7 +168,8 @@ void loop() {
 
    case 's': {
       Serial.print("Track size (bytes remaining/total): ");
-      uint32_t remain, total;
+      uint32_t remain = 0;
+	  uint32_t total = 0;
       if (! sfx.trackSize(&remain, &total) ) 
         Serial.println("Failed to query");
       Serial.print(remain); Serial.print("/"); Serial.println(total); 

--- a/examples/menucommands/menucommands.ino
+++ b/examples/menucommands/menucommands.ino
@@ -49,8 +49,7 @@ void setup() {
 
 
 void loop() {
-  flushInput();
-  
+
   Serial.println(F("What would you like to do?"));
   Serial.println(F("[r] - reset"));
   Serial.println(F("[+] - Vol +"));
@@ -64,12 +63,12 @@ void loop() {
   Serial.println(F("[t] - playtime status"));
   Serial.println(F("> "));
   
-  while (!Serial.available());
-  char cmd = Serial.read();
-  
-  flushInput();
-  
-  switch (cmd) {
+  // Read the response.  We will only use the first letter, read the line to clear everything sent (like the line return).
+  const uint8_t bufferSize = 20;
+  char lineBuffer[bufferSize];
+  readline(lineBuffer, bufferSize);
+
+  switch (lineBuffer[0]) {
     case 'r': {
       if (!sfx.reset()) {
         Serial.println("Reset failed");
@@ -106,11 +105,10 @@ void loop() {
     
     case 'P': {
       Serial.print("Enter track name (full 12 character name!) >");
-      char name[20];
-      readline(name, 20);
+      readline(lineBuffer, bufferSize);
 
-      Serial.print("\nPlaying track \""); Serial.print(name); Serial.print("\"");
-      if (! sfx.playTrack(name) ) {
+      Serial.print("\nPlaying track \""); Serial.print(lineBuffer); Serial.print("\"");
+      if (! sfx.playTrack(lineBuffer) ) {
         Serial.println("Failed to play track?");
       }
       break;
@@ -185,18 +183,6 @@ void loop() {
 
 
 /************************ MENU HELPERS ***************************/
-
-void flushInput() {
-  // Read all available serial input to flush pending data.
-  uint16_t timeoutloop = 0;
-  while (timeoutloop++ < 40) {
-    while(ss.available()) {
-      ss.read();
-      timeoutloop = 0;  // If char was received reset the timer
-    }
-    delay(1);
-  }
-}
 
 char readBlocking() {
   while (!Serial.available());


### PR DESCRIPTION
Commits 1 & 2 - Fixes compiler warnings
In the first commit, an unused variable was removed to prevent a compiler warning.  No functionality was changed.
In the second commit, variables we initialized to prevent compiler warnings.

With these two commits, the code will now compile in the Arduino IDE without compiler warnings.  Having compiler warnings is a bad practice and they should be eliminated if at all possible.

Commit 3 - Fixes double printing of command menu
The reading of the command failed to read the line return, resulting in a double printing of the input menu.  Switching to using the "readline" command eliminated this as well as provides some extract protection against extraneous data entry.

The function "flushInput" was supposed to clear any extra data, but it did not work in my testing.  See the commit for more details.  After switching to "readline" the "flushInput" function was no longer needed and removed.

Commit 4 - Use of the "F()" macro
Use "F()" macro on all string constants inside of "println" functions.  This is to reduce the amount of dynamic memory used and to make the code internally consistent.  The macro was used in some places, but not others.

Commit 5 - User interface
Fixed user interface to be self-consistent with input and feedback.  Output to inform the user and methods for prompting the user for input were inconsistent.

Added a "default" to the switch statement to inform the user when the input was invalid.

Fixed inconsistent formatting in the switch statement.