### PR TITLE
Getting the correct volume value back

### DIFF
--- a/Adafruit_Soundboard.cpp
+++ b/Adafruit_Soundboard.cpp
@@ -221,7 +221,8 @@ uint8_t Adafruit_Soundboard::volUp() {
   while (stream->available())
     stream->read();
 
-  stream->println("+");
+  write("+");
+  write('\r');
   readLine();
   // Serial.println(line_buffer);
 
@@ -234,7 +235,8 @@ uint8_t Adafruit_Soundboard::volDown() {
   while (stream->available())
     stream->read();
 
-  stream->println("-");
+  write("-");
+  write('\r');
   readLine();
   // Serial.println(line_buffer);
 


### PR DESCRIPTION
I got very jittery results back from the chip when changing volume in UART mode. Found this thread that proposed a solution that worked perfectly for me. 

https://forums.adafruit.com/viewtopic.php?p=373887&hilit=soundboard+volume#p373887

From the thread:
The issue is that after sending the + or - command, the soundboard returns "high bit line noise" (sic) instead of the five-digit response sentence. this occurs about 10% of the time. no amount of flush, delay, etc, would fix it. it's definitely a firmware problem. 

the "problem" is that the code as shipped:
```
CODE: SELECT ALL
        stream-> println ("+");
```
... transmits +, CR, then a spurious LF. it's the LF that triggers the "line noise". sending only the + (or -) and CR solves it; more specifically it hasn't happened "for a long time" since the change.
